### PR TITLE
Fix Sessions parsing

### DIFF
--- a/bloodhound_import/importer.py
+++ b/bloodhound_import/importer.py
@@ -227,7 +227,7 @@ def parse_computer(tx, computer):
     if 'Sessions' in computer and computer['Sessions']:
         query = build_add_edge_query('Computer', 'User', 'HasSession', '{isacl:false}')
         for entry in computer['Sessions']:
-            queries.append(Query(query, dict(source=entry['MemberId'], target=identifier)))
+            queries.append(Query(query, dict(source=entry['UserId'], target=identifier)))
 
     if 'Aces' in computer and computer['Aces'] is not None:
         queries.extend(process_ace_list(computer['Aces'], identifier, "Computer"))


### PR DESCRIPTION
When `Sessions` are available in `computers.json`, their format is `{'ComputerId':objectsid, 'UserId':taskuser}` (according to Bloodhound.py https://github.com/fox-it/BloodHound.py/blob/fd793b94d6e3a4238c5451ab76915bce59ae5ed0/bloodhound/enumeration/computers.py#L188 and SharpHound3 https://github.com/BloodHoundAD/SharpHound3/blob/master/SharpHound3/JSON/Session.cs).