### PR TITLE
Fix acl nodes label

### DIFF
--- a/bloodhound_import/importer.py
+++ b/bloodhound_import/importer.py
@@ -62,7 +62,7 @@ def process_ace_list(ace_list: list, objectid: str, objecttype: str) -> list:
             rights.append(RIGHTS_MAP[right])
 
         for right in rights:
-            query = build_add_edge_query(objecttype, principaltype, right, '{isacl: true, isinherited: prop.isinherited}')
+            query = build_add_edge_query(principaltype, objecttype, right, '{isacl: true, isinherited: prop.isinherited}')
             props = dict(
                 source=principal,
                 target=objectid,


### PR DESCRIPTION
https://github.com/fox-it/bloodhound-import/commit/0275cff6e5046ccf96c5c34f998be391618d3059 inverted the direction of ACL edges, but did not update node labels assignment. Therefore, nodes have currently wrong labels.