### PR TITLE
Handle cases where ACL targets are a string instead of an object

### DIFF
--- a/bloodhound_import/__init__.py
+++ b/bloodhound_import/__init__.py
@@ -8,22 +8,44 @@ from neo4j.exceptions import ClientError
 
 async def main():
     """
-        Main function
+    Main function
     """
     argparser = argparse.ArgumentParser("bloodhound-import.py")
     argparser.add_argument("files", help="Files to parse.", nargs="+")
-    argparser.add_argument("-du", "--database-user", help="Username to connect to neo4j, if not specified will try to auto detect a config file.")
-    argparser.add_argument("-dp", "--database-password", help="Password to connect to neo4j, if not specified will try to auto detect a config file.")
-    argparser.add_argument("--database", help="The host neo4j is running on.", default="localhost")
+    argparser.add_argument(
+        "-du",
+        "--database-user",
+        help="Username to connect to neo4j, if not specified will try to auto detect a config file.",
+    )
+    argparser.add_argument(
+        "-dp",
+        "--database-password",
+        help="Password to connect to neo4j, if not specified will try to auto detect a config file.",
+    )
+    argparser.add_argument(
+        "--database", help="The host neo4j is running on.", default="localhost"
+    )
     argparser.add_argument("-p", "--port", help="Port of neo4j", default=7687)
-    argparser.add_argument("-s", "--scheme", help="URI Scheme used to communicate with neo4j", default="bolt")
-    argparser.add_argument("-v", "--verbose", help="Verbose output", action='store_true')
+    argparser.add_argument(
+        "-s",
+        "--scheme",
+        help="URI Scheme used to communicate with neo4j",
+        default="bolt",
+    )
+    argparser.add_argument(
+        "-v", "--verbose", help="Verbose output", action="store_true"
+    )
     arguments = argparser.parse_args()
 
     if arguments.database_password is None:
-        arguments.database_user, arguments.database_password = database.detect_db_config()
+        (
+            arguments.database_user,
+            arguments.database_password,
+        ) = database.detect_db_config()
         if arguments.database_password is None:
-            logging.error('Error: Could not autodetect the Neo4j database credentials from your BloodHound config. Please specify them manually')
+            logging.error(
+                "Error: Could not autodetect the Neo4j database credentials from your BloodHound config. Please specify them manually"
+            )
             return
 
     logging.basicConfig(format="[%(levelname)s] %(asctime)s - %(message)s")
@@ -32,7 +54,13 @@ async def main():
     else:
         logging.getLogger().setLevel(logging.INFO)
 
-    driver = database.init_driver(arguments.database, arguments.port, arguments.scheme, arguments.database_user, arguments.database_password)
+    driver = database.init_driver(
+        arguments.database,
+        arguments.port,
+        arguments.scheme,
+        arguments.database_user,
+        arguments.database_password,
+    )
 
     try:
         try:

--- a/bloodhound_import/database.py
+++ b/bloodhound_import/database.py
@@ -20,52 +20,54 @@ def detect_db_config():
     OS dependent according to https://electronjs.org/docs/api/app#appgetpathname
     """
     system = platform.system()
-    if system == 'Windows':
+    if system == "Windows":
         try:
-            directory = os.environ['APPDATA']
+            directory = os.environ["APPDATA"]
         except KeyError:
             return (None, None)
-        config = os.path.join(directory, 'BloodHound', 'config.json')
+        config = os.path.join(directory, "BloodHound", "config.json")
         try:
-            with open(config, 'r') as configfile:
+            with open(config, "r") as configfile:
                 configdata = json.load(configfile)
         except IOError:
             return (None, None)
 
-    if system == 'Linux':
+    if system == "Linux":
         try:
-            directory = os.environ['XDG_CONFIG_HOME']
+            directory = os.environ["XDG_CONFIG_HOME"]
         except KeyError:
             try:
-                directory = os.path.join(os.environ['HOME'], '.config')
+                directory = os.path.join(os.environ["HOME"], ".config")
             except KeyError:
                 return (None, None)
-        config = os.path.join(directory, 'bloodhound', 'config.json')
+        config = os.path.join(directory, "bloodhound", "config.json")
         try:
-            with open(config, 'r') as configfile:
+            with open(config, "r") as configfile:
                 configdata = json.load(configfile)
         except IOError:
             return (None, None)
 
-    if system == 'Darwin':
+    if system == "Darwin":
         try:
-            directory = os.path.join(os.environ['HOME'], 'Library', 'Application Support')
+            directory = os.path.join(
+                os.environ["HOME"], "Library", "Application Support"
+            )
         except KeyError:
             return (None, None)
-        config = os.path.join(directory, 'bloodhound', 'config.json')
+        config = os.path.join(directory, "bloodhound", "config.json")
         try:
-            with open(config, 'r') as configfile:
+            with open(config, "r") as configfile:
                 configdata = json.load(configfile)
         except IOError:
             return (None, None)
 
     # If we are still here, we apparently found the config :)
     try:
-        username = configdata['databaseInfo']['user']
+        username = configdata["databaseInfo"]["user"]
     except KeyError:
-        username = 'neo4j'
+        username = "neo4j"
     try:
-        password = configdata['databaseInfo']['password']
+        password = configdata["databaseInfo"]["password"]
     except KeyError:
         password = None
     return username, password

--- a/bloodhound_import/importer.py
+++ b/bloodhound_import/importer.py
@@ -19,37 +19,50 @@ class Query:
 SYNC_COUNT = 100
 
 
-def build_add_edge_query(source_label: str, target_label: str, edge_type: str, edge_props: str) -> str:
+def build_add_edge_query(
+    source_label: str, target_label: str, edge_type: str, edge_props: str
+) -> str:
     """Build a standard edge insert query based on the given params"""
-    insert_query = 'UNWIND $props AS prop MERGE (n:Base {{objectid: prop.source}}) SET n:{0} MERGE (m:Base {{objectid: prop.target}}) SET m:{1} MERGE (n)-[r:{2} {3}]->(m)'
+    insert_query = "UNWIND $props AS prop MERGE (n:Base {{objectid: prop.source}}) SET n:{0} MERGE (m:Base {{objectid: prop.target}}) SET m:{1} MERGE (n)-[r:{2} {3}]->(m)"
     return insert_query.format(source_label, target_label, edge_type, edge_props)
 
 
-async def process_ace_list(ace_list: list, objectid: str, objecttype: str, tx: neo4j.Transaction) -> None:
+async def process_ace_list(
+    ace_list: list, objectid: str, objecttype: str, tx: neo4j.Transaction
+) -> None:
     for entry in ace_list:
-        principal = entry['PrincipalSID']
-        principaltype = entry['PrincipalType']
-        right = entry['RightName']
+        principal = entry["PrincipalSID"]
+        principaltype = entry["PrincipalType"]
+        right = entry["RightName"]
 
         if objectid == principal:
             continue
 
-        query = build_add_edge_query(principaltype, objecttype, right, '{isacl: true, isinherited: prop.isinherited}')
+        query = build_add_edge_query(
+            principaltype,
+            objecttype,
+            right,
+            "{isacl: true, isinherited: prop.isinherited}",
+        )
         props = dict(
             source=principal,
             target=objectid,
-            isinherited=entry['IsInherited'],
+            isinherited=entry["IsInherited"],
         )
         await tx.run(query, props=props)
 
 
-async def process_spntarget_list(spntarget_list: list, objectid: str, tx: neo4j.Transaction) -> None:
+async def process_spntarget_list(
+    spntarget_list: list, objectid: str, tx: neo4j.Transaction
+) -> None:
     for entry in spntarget_list:
-        query = build_add_edge_query('User', 'Computer', '', '{isacl: false, port: prop.port}')
+        query = build_add_edge_query(
+            "User", "Computer", "", "{isacl: false, port: prop.port}"
+        )
         props = dict(
             source=objectid,
-            target=entry['ComputerSID'],
-            port=entry['Port'],
+            target=entry["ComputerSID"],
+            port=entry["Port"],
         )
         await tx.run(query, props=props)
 
@@ -60,11 +73,21 @@ async def add_constraints(tx: neo4j.Transaction):
     Arguments:
         tx {neo4j.Transaction} -- Neo4j transaction.
     """
-    await tx.run('CREATE CONSTRAINT base_objectid_unique ON (b:Base) ASSERT b.objectid IS UNIQUE')
-    await tx.run('CREATE CONSTRAINT computer_objectid_unique ON (c:Computer) ASSERT c.objectid IS UNIQUE')
-    await tx.run('CREATE CONSTRAINT domain_objectid_unique ON (d:Domain) ASSERT d.objectid IS UNIQUE')
-    await tx.run('CREATE CONSTRAINT group_objectid_unique ON (g:Group) ASSERT g.objectid IS UNIQUE')
-    await tx.run('CREATE CONSTRAINT user_objectid_unique ON (u:User) ASSERT u.objectid IS UNIQUE')
+    await tx.run(
+        "CREATE CONSTRAINT base_objectid_unique ON (b:Base) ASSERT b.objectid IS UNIQUE"
+    )
+    await tx.run(
+        "CREATE CONSTRAINT computer_objectid_unique ON (c:Computer) ASSERT c.objectid IS UNIQUE"
+    )
+    await tx.run(
+        "CREATE CONSTRAINT domain_objectid_unique ON (d:Domain) ASSERT d.objectid IS UNIQUE"
+    )
+    await tx.run(
+        "CREATE CONSTRAINT group_objectid_unique ON (g:Group) ASSERT g.objectid IS UNIQUE"
+    )
+    await tx.run(
+        "CREATE CONSTRAINT user_objectid_unique ON (u:User) ASSERT u.objectid IS UNIQUE"
+    )
     await tx.run("CREATE CONSTRAINT ON (c:User) ASSERT c.name IS UNIQUE")
     await tx.run("CREATE CONSTRAINT ON (c:Computer) ASSERT c.name IS UNIQUE")
     await tx.run("CREATE CONSTRAINT ON (c:Group) ASSERT c.name IS UNIQUE")
@@ -80,42 +103,65 @@ async def parse_ou(tx: neo4j.Transaction, ou: dict):
         tx {neo4j.Transaction} -- Neo4j session
         ou {dict} -- Single ou object.
     """
-    identifier = ou['ObjectIdentifier'].upper()
-    property_query = 'UNWIND $props AS prop MERGE (n:Base {objectid: prop.source}) SET n:OU SET n += prop.map'
-    props = {'map': ou['Properties'], 'source': identifier}
+    identifier = ou["ObjectIdentifier"].upper()
+    property_query = "UNWIND $props AS prop MERGE (n:Base {objectid: prop.source}) SET n:OU SET n += prop.map"
+    props = {"map": ou["Properties"], "source": identifier}
     await tx.run(property_query, props=props)
 
-    if 'Aces' in ou and ou['Aces'] is not None:
-        await process_ace_list(ou['Aces'], identifier, "OU", tx)
+    if "Aces" in ou and ou["Aces"] is not None:
+        await process_ace_list(ou["Aces"], identifier, "OU", tx)
 
-    if 'ChildObjects' in ou and ou['ChildObjects']:
-        targets = ou['ChildObjects']
+    if "ChildObjects" in ou and ou["ChildObjects"]:
+        targets = ou["ChildObjects"]
         for target in targets:
-            query = build_add_edge_query('OU', target['ObjectType'], 'Contains', '{isacl: false}')
-            await tx.run(query, props=dict(source=identifier, target=target['ObjectIdentifier']))
+            query = build_add_edge_query(
+                "OU", target["ObjectType"], "Contains", "{isacl: false}"
+            )
+            await tx.run(
+                query, props=dict(source=identifier, target=target["ObjectIdentifier"])
+            )
 
-    if 'Links' in ou and ou['Links']:
-        query = build_add_edge_query('GPO', 'OU', 'GpLink', '{isacl: false, enforced: prop.enforced}')
-        for gpo in ou['Links']:
-            await tx.run(query, props=dict(source=identifier, target=gpo['GUID'].upper(), enforced=gpo['IsEnforced']))
+    if "Links" in ou and ou["Links"]:
+        query = build_add_edge_query(
+            "GPO", "OU", "GpLink", "{isacl: false, enforced: prop.enforced}"
+        )
+        for gpo in ou["Links"]:
+            await tx.run(
+                query,
+                props=dict(
+                    source=identifier,
+                    target=gpo["GUID"].upper(),
+                    enforced=gpo["IsEnforced"],
+                ),
+            )
 
     options = [
-        ('LocalAdmins', 'AdminTo'),
-        ('PSRemoteUsers', 'CanPSRemote'),
-        ('DcomUsers', 'ExecuteDCOM'),
-        ('RemoteDesktopUsers', 'CanRDP'),
+        ("LocalAdmins", "AdminTo"),
+        ("PSRemoteUsers", "CanPSRemote"),
+        ("DcomUsers", "ExecuteDCOM"),
+        ("RemoteDesktopUsers", "CanRDP"),
     ]
 
-    if 'GPOChanges' in ou and ou['GPOChanges']:
-        gpo_changes = ou['GPOChanges']
-        affected_computers = gpo_changes['AffectedComputers']
+    if "GPOChanges" in ou and ou["GPOChanges"]:
+        gpo_changes = ou["GPOChanges"]
+        affected_computers = gpo_changes["AffectedComputers"]
         for option, edge_name in options:
             if option in gpo_changes and gpo_changes[option]:
                 targets = gpo_changes[option]
                 for target in targets:
-                    query = build_add_edge_query(target['ObjectType'], 'Computer', edge_name, '{isacl: false, fromgpo: true}')
+                    query = build_add_edge_query(
+                        target["ObjectType"],
+                        "Computer",
+                        edge_name,
+                        "{isacl: false, fromgpo: true}",
+                    )
                     for computer in affected_computers:
-                        await tx.run(query, props=dict(target=computer, source=target['ObjectIdentifier']))
+                        await tx.run(
+                            query,
+                            props=dict(
+                                target=computer, source=target["ObjectIdentifier"]
+                            ),
+                        )
 
 
 async def parse_gpo(tx: neo4j.Transaction, gpo: dict):
@@ -125,14 +171,14 @@ async def parse_gpo(tx: neo4j.Transaction, gpo: dict):
         tx {neo4j.Transaction} -- Neo4j transaction
         gpo {dict} -- Single gpo object.
     """
-    identifier = gpo['ObjectIdentifier']
+    identifier = gpo["ObjectIdentifier"]
 
-    query = 'UNWIND $props AS prop MERGE (n:Base {objectid: prop.source}) SET n:GPO SET n += prop.map'
-    props = {'map': gpo['Properties'], 'source': identifier}
+    query = "UNWIND $props AS prop MERGE (n:Base {objectid: prop.source}) SET n:GPO SET n += prop.map"
+    props = {"map": gpo["Properties"], "source": identifier}
     await tx.run(query, props=props)
 
     if "Aces" in gpo and gpo["Aces"] is not None:
-        await process_ace_list(gpo['Aces'], identifier, "GPO", tx)
+        await process_ace_list(gpo["Aces"], identifier, "GPO", tx)
 
 
 async def parse_computer(tx: neo4j.Transaction, computer: dict):
@@ -142,54 +188,70 @@ async def parse_computer(tx: neo4j.Transaction, computer: dict):
         session {neo4j.Transaction} -- Neo4j transaction
         computer {dict} -- Single computer object.
     """
-    identifier = computer['ObjectIdentifier']
+    identifier = computer["ObjectIdentifier"]
 
-    property_query = 'UNWIND $props AS prop MERGE (n:Base {objectid: prop.source}) SET n:Computer SET n += prop.map'
-    props = {'map': computer['Properties'], 'source': identifier}
+    property_query = "UNWIND $props AS prop MERGE (n:Base {objectid: prop.source}) SET n:Computer SET n += prop.map"
+    props = {"map": computer["Properties"], "source": identifier}
 
     await tx.run(property_query, props=props)
 
-    if 'PrimaryGroupSid' in computer and computer['PrimaryGroupSid']:
-        query = build_add_edge_query('Computer', 'Group', 'MemberOf', '{isacl:false}')
-        await tx.run(query, props=dict(source=identifier, target=computer['PrimaryGroupSid']))
+    if "PrimaryGroupSid" in computer and computer["PrimaryGroupSid"]:
+        query = build_add_edge_query("Computer", "Group", "MemberOf", "{isacl:false}")
+        await tx.run(
+            query, props=dict(source=identifier, target=computer["PrimaryGroupSid"])
+        )
 
-    if 'AllowedToDelegate' in computer and computer['AllowedToDelegate']:
-        query = build_add_edge_query('Computer', 'Group', 'MemberOf', '{isacl:false}')
-        for entry in computer['AllowedToDelegate']:
-            await tx.run(query, props=dict(source=identifier, target=entry['ObjectIdentifier']))
+    if "AllowedToDelegate" in computer and computer["AllowedToDelegate"]:
+        query = build_add_edge_query("Computer", "Group", "MemberOf", "{isacl:false}")
+        for entry in computer["AllowedToDelegate"]:
+            await tx.run(
+                query, props=dict(source=identifier, target=entry["ObjectIdentifier"])
+            )
 
     # (Property name, Edge name, Use "Results" format)
     options = [
-        ('LocalAdmins', 'AdminTo', True),
-        ('RemoteDesktopUsers', 'CanRDP', True),
-        ('DcomUsers', 'ExecuteDCOM', True),
-        ('PSRemoteUsers', 'CanPSRemote', True),
-        ('AllowedToAct', 'AllowedToAct', False),
-        ('AllowedToDelegate', 'AllowedToDelegate', False),
+        ("LocalAdmins", "AdminTo", True),
+        ("RemoteDesktopUsers", "CanRDP", True),
+        ("DcomUsers", "ExecuteDCOM", True),
+        ("PSRemoteUsers", "CanPSRemote", True),
+        ("AllowedToAct", "AllowedToAct", False),
+        ("AllowedToDelegate", "AllowedToDelegate", False),
     ]
 
     for option, edge_name, use_results in options:
         if option in computer:
-            targets = computer[option]['Results'] if use_results else computer[option]
+            targets = computer[option]["Results"] if use_results else computer[option]
             for target in targets:
-                query = build_add_edge_query(target['ObjectType'], 'Computer', edge_name, '{isacl:false, fromgpo: false}')
-                await tx.run(query, props=dict(source=target['ObjectIdentifier'], target=identifier))
+                query = build_add_edge_query(
+                    target["ObjectType"],
+                    "Computer",
+                    edge_name,
+                    "{isacl:false, fromgpo: false}",
+                )
+                await tx.run(
+                    query,
+                    props=dict(source=target["ObjectIdentifier"], target=identifier),
+                )
 
     # (Session type, source)
     session_types = [
-        ('Sessions', 'netsessionenum'),
-        ('PrivilegedSessions', 'netwkstauserenum'),
-        ('RegistrySessions', 'registry'),
+        ("Sessions", "netsessionenum"),
+        ("PrivilegedSessions", "netwkstauserenum"),
+        ("RegistrySessions", "registry"),
     ]
 
     for session_type, source in session_types:
-        if session_type in computer and computer[session_type]['Results']:
-            query = build_add_edge_query('Computer', 'User', 'HasSession', '{isacl:false, source:"%s"}' % source)
-            for entry in computer[session_type]['Results']:
-                await tx.run(query, props=dict(source=entry['UserSID'], target=identifier))
+        if session_type in computer and computer[session_type]["Results"]:
+            query = build_add_edge_query(
+                "Computer", "User", "HasSession", '{isacl:false, source:"%s"}' % source
+            )
+            for entry in computer[session_type]["Results"]:
+                await tx.run(
+                    query, props=dict(source=entry["UserSID"], target=identifier)
+                )
 
-    if 'Aces' in computer and computer['Aces'] is not None:
-        await process_ace_list(computer['Aces'], identifier, "Computer", tx)
+    if "Aces" in computer and computer["Aces"] is not None:
+        await process_ace_list(computer["Aces"], identifier, "Computer", tx)
 
 
 async def parse_user(tx: neo4j.Transaction, user: dict):
@@ -199,28 +261,34 @@ async def parse_user(tx: neo4j.Transaction, user: dict):
         tx {neo4j.Transaction} -- Neo4j session
         user {dict} -- Single user object from the bloodhound json.
     """
-    identifier = user['ObjectIdentifier']
-    property_query = 'UNWIND $props AS prop MERGE (n:Base {objectid: prop.source}) SET n:User SET n += prop.map'
-    props = {'map': user['Properties'], 'source': identifier}
+    identifier = user["ObjectIdentifier"]
+    property_query = "UNWIND $props AS prop MERGE (n:Base {objectid: prop.source}) SET n:User SET n += prop.map"
+    props = {"map": user["Properties"], "source": identifier}
 
     await tx.run(property_query, props=props)
 
-    if 'PrimaryGroupSid' in user and user['PrimaryGroupSid']:
-        query = build_add_edge_query('User', 'Group', 'MemberOf', '{isacl: false}')
-        await tx.run(query, props=dict(source=identifier, target=user['PrimaryGroupSid']))
+    if "PrimaryGroupSid" in user and user["PrimaryGroupSid"]:
+        query = build_add_edge_query("User", "Group", "MemberOf", "{isacl: false}")
+        await tx.run(
+            query, props=dict(source=identifier, target=user["PrimaryGroupSid"])
+        )
 
-    if 'AllowedToDelegate' in user and user['AllowedToDelegate']:
-        query = build_add_edge_query('User', 'Computer', 'AllowedToDelegate', '{isacl: false}')
-        for entry in user['AllowedToDelegate']:
-            await tx.run(query, props=dict(source=identifier, target=entry['ObjectIdentifier']))
+    if "AllowedToDelegate" in user and user["AllowedToDelegate"]:
+        query = build_add_edge_query(
+            "User", "Computer", "AllowedToDelegate", "{isacl: false}"
+        )
+        for entry in user["AllowedToDelegate"]:
+            await tx.run(
+                query, props=dict(source=identifier, target=entry["ObjectIdentifier"])
+            )
 
     # TODO add HasSIDHistory objects
 
-    if 'Aces' in user and user['Aces'] is not None:
-        await process_ace_list(user['Aces'], identifier, "User", tx)
+    if "Aces" in user and user["Aces"] is not None:
+        await process_ace_list(user["Aces"], identifier, "User", tx)
 
-    if 'SPNTargets' in user and user['SPNTargets'] is not None:
-        await process_spntarget_list(user['SPNTargets'], identifier, tx)
+    if "SPNTargets" in user and user["SPNTargets"] is not None:
+        await process_spntarget_list(user["SPNTargets"], identifier, tx)
 
 
 async def parse_group(tx: neo4j.Transaction, group: dict):
@@ -230,20 +298,24 @@ async def parse_group(tx: neo4j.Transaction, group: dict):
         tx {neo4j.Transaction} -- Neo4j Transaction
         group {dict} -- Single group object from the bloodhound json.
     """
-    properties = group['Properties']
-    identifier = group['ObjectIdentifier']
-    members = group['Members']
+    properties = group["Properties"]
+    identifier = group["ObjectIdentifier"]
+    members = group["Members"]
 
-    property_query = 'UNWIND $props AS prop MERGE (n:Base {objectid: prop.source}) SET n:Group SET n += prop.map'
-    props = {'map': properties, 'source': identifier}
+    property_query = "UNWIND $props AS prop MERGE (n:Base {objectid: prop.source}) SET n:Group SET n += prop.map"
+    props = {"map": properties, "source": identifier}
     await tx.run(property_query, props=props)
 
-    if 'Aces' in group and group['Aces'] is not None:
-        await process_ace_list(group['Aces'], identifier, "Group", tx)
+    if "Aces" in group and group["Aces"] is not None:
+        await process_ace_list(group["Aces"], identifier, "Group", tx)
 
     for member in members:
-        query = build_add_edge_query(member['ObjectType'], 'Group', 'MemberOf', '{isacl: false}')
-        await tx.run(query, props=dict(source=member['ObjectIdentifier'], target=identifier))
+        query = build_add_edge_query(
+            member["ObjectType"], "Group", "MemberOf", "{isacl: false}"
+        )
+        await tx.run(
+            query, props=dict(source=member["ObjectIdentifier"], target=identifier)
+        )
 
 
 async def parse_domain(tx: neo4j.Transaction, domain: dict):
@@ -253,73 +325,107 @@ async def parse_domain(tx: neo4j.Transaction, domain: dict):
         tx {neo4j.Transaction} -- Neo4j Transaction
         domain {dict} -- Single domain object from the bloodhound json.
     """
-    identifier = domain['ObjectIdentifier']
-    property_query = 'UNWIND $props AS prop MERGE (n:Base {objectid: prop.source}) SET n:Domain SET n += prop.map'
-    props = {'map': domain['Properties'], 'source': identifier}
+    identifier = domain["ObjectIdentifier"]
+    property_query = "UNWIND $props AS prop MERGE (n:Base {objectid: prop.source}) SET n:Domain SET n += prop.map"
+    props = {"map": domain["Properties"], "source": identifier}
     await tx.run(property_query, props=props)
 
-    if 'Aces' in domain and domain['Aces'] is not None:
-        await process_ace_list(domain['Aces'], identifier, 'Domain', tx)
+    if "Aces" in domain and domain["Aces"] is not None:
+        await process_ace_list(domain["Aces"], identifier, "Domain", tx)
 
-    trust_map = {0: 'ParentChild', 1: 'CrossLink', 2: 'Forest', 3: 'External', 4: 'Unknown'}
-    if 'Trusts' in domain and domain['Trusts'] is not None:
-        query = build_add_edge_query('Domain', 'Domain', 'TrustedBy', '{sidfiltering: prop.sidfiltering, trusttype: prop.trusttype, transitive: prop.transitive, isacl: false}')
-        for trust in domain['Trusts']:
-            trust_type = trust['TrustType']
-            direction = trust['TrustDirection']
+    trust_map = {
+        0: "ParentChild",
+        1: "CrossLink",
+        2: "Forest",
+        3: "External",
+        4: "Unknown",
+    }
+    if "Trusts" in domain and domain["Trusts"] is not None:
+        query = build_add_edge_query(
+            "Domain",
+            "Domain",
+            "TrustedBy",
+            "{sidfiltering: prop.sidfiltering, trusttype: prop.trusttype, transitive: prop.transitive, isacl: false}",
+        )
+        for trust in domain["Trusts"]:
+            trust_type = trust["TrustType"]
+            direction = trust["TrustDirection"]
             props = {}
             if direction in [1, 3]:
                 props = dict(
                     source=identifier,
-                    target=trust['TargetDomainSid'],
+                    target=trust["TargetDomainSid"],
                     trusttype=trust_map[trust_type],
-                    transitive=trust['IsTransitive'],
-                    sidfiltering=trust['SidFilteringEnabled'],
+                    transitive=trust["IsTransitive"],
+                    sidfiltering=trust["SidFilteringEnabled"],
                 )
             elif direction in [2, 4]:
                 props = dict(
                     target=identifier,
-                    source=trust['TargetDomainSid'],
+                    source=trust["TargetDomainSid"],
                     trusttype=trust_map[trust_type],
-                    transitive=trust['IsTransitive'],
-                    sidfiltering=trust['SidFilteringEnabled'],
+                    transitive=trust["IsTransitive"],
+                    sidfiltering=trust["SidFilteringEnabled"],
                 )
             else:
-                logging.error("Could not determine direction of trust... direction: %s", direction)
+                logging.error(
+                    "Could not determine direction of trust... direction: %s", direction
+                )
                 continue
             await tx.run(query, props=props)
 
-    if 'ChildObjects' in domain and domain['ChildObjects']:
-        targets = domain['ChildObjects']
+    if "ChildObjects" in domain and domain["ChildObjects"]:
+        targets = domain["ChildObjects"]
         for target in targets:
-            query = build_add_edge_query('Domain', target['ObjectType'], 'Contains', '{isacl: false}')
-            await tx.run(query, props=dict(source=identifier, target=target['ObjectIdentifier']))
+            query = build_add_edge_query(
+                "Domain", target["ObjectType"], "Contains", "{isacl: false}"
+            )
+            await tx.run(
+                query, props=dict(source=identifier, target=target["ObjectIdentifier"])
+            )
 
-    if 'Links' in domain and domain['Links']:
-        query = build_add_edge_query('GPO', 'OU', 'GpLink', '{isacl: false, enforced: prop.enforced}')
-        for gpo in domain['Links']:
+    if "Links" in domain and domain["Links"]:
+        query = build_add_edge_query(
+            "GPO", "OU", "GpLink", "{isacl: false, enforced: prop.enforced}"
+        )
+        for gpo in domain["Links"]:
             await tx.run(
                 query,
-                props=dict(source=identifier, target=gpo['GUID'].upper(), enforced=gpo['IsEnforced'])
+                props=dict(
+                    source=identifier,
+                    target=gpo["GUID"].upper(),
+                    enforced=gpo["IsEnforced"],
+                ),
             )
 
     options = [
-        ('LocalAdmins', 'AdminTo'),
-        ('PSRemoteUsers', 'CanPSRemote'),
-        ('DcomUsers', 'ExecuteDCOM'),
-        ('RemoteDesktopUsers', 'CanRDP'),
+        ("LocalAdmins", "AdminTo"),
+        ("PSRemoteUsers", "CanPSRemote"),
+        ("DcomUsers", "ExecuteDCOM"),
+        ("RemoteDesktopUsers", "CanRDP"),
     ]
 
-    if 'GPOChanges' in domain and domain['GPOChanges']:
-        gpo_changes = domain['GPOChanges']
-        affected_computers = gpo_changes['AffectedComputers']
+    if "GPOChanges" in domain and domain["GPOChanges"]:
+        gpo_changes = domain["GPOChanges"]
+        affected_computers = gpo_changes["AffectedComputers"]
         for option, edge_name in options:
             if option in gpo_changes and gpo_changes[option]:
                 targets = gpo_changes[option]
                 for target in targets:
-                    query = build_add_edge_query(target['ObjectType'], 'Computer', edge_name, '{isacl: false, fromgpo: true}')
+                    query = build_add_edge_query(
+                        target["ObjectType"],
+                        "Computer",
+                        edge_name,
+                        "{isacl: false, fromgpo: true}",
+                    )
                     for computer in affected_computers:
-                        await tx.run(query, props=dict(target=computer, source=target['ObjectIdentifier']))
+                        await tx.run(
+                            query,
+                            props=dict(
+                                target=computer, source=target["ObjectIdentifier"]
+                            ),
+                        )
+
 
 async def parse_container(tx: neo4j.Transaction, container: dict):
     """Parse a Container object.
@@ -328,20 +434,25 @@ async def parse_container(tx: neo4j.Transaction, container: dict):
         tx {neo4j.Transaction} -- Neo4j session
         container {dict} -- Single container object from the bloodhound json.
     """
-    identifier = container['ObjectIdentifier']
-    property_query = 'UNWIND $props AS prop MERGE (n:Base {objectid: prop.source}) SET n:Container SET n += prop.map'
-    props = {'map': container['Properties'], 'source': identifier}
+    identifier = container["ObjectIdentifier"]
+    property_query = "UNWIND $props AS prop MERGE (n:Base {objectid: prop.source}) SET n:Container SET n += prop.map"
+    props = {"map": container["Properties"], "source": identifier}
 
     await tx.run(property_query, props=props)
 
-    if 'Aces' in container and container['Aces'] is not None:
-        await process_ace_list(container['Aces'], identifier, "Container", tx)
+    if "Aces" in container and container["Aces"] is not None:
+        await process_ace_list(container["Aces"], identifier, "Container", tx)
 
-    if 'ChildObjects' in container and container['ChildObjects']:
-        targets = container['ChildObjects']
+    if "ChildObjects" in container and container["ChildObjects"]:
+        targets = container["ChildObjects"]
         for target in targets:
-            query = build_add_edge_query('Container', target['ObjectType'], 'Contains', '{isacl: false}')
-            await tx.run(query, props=dict(source=identifier, target=target['ObjectIdentifier']))
+            query = build_add_edge_query(
+                "Container", target["ObjectType"], "Contains", "{isacl: false}"
+            )
+            await tx.run(
+                query, props=dict(source=identifier, target=target["ObjectIdentifier"])
+            )
+
 
 async def parse_file(filename: str, driver: neo4j.AsyncDriver):
     """Parse a bloodhound file.
@@ -352,20 +463,20 @@ async def parse_file(filename: str, driver: neo4j.AsyncDriver):
     """
     logging.info("Parsing bloodhound file: %s", filename)
 
-    with codecs.open(filename, 'r', encoding='utf-8-sig') as f:
-        meta = ijson.items(f, 'meta')
+    with codecs.open(filename, "r", encoding="utf-8-sig") as f:
+        meta = ijson.items(f, "meta")
         for o in meta:
-            obj_type = o['type']
-            total = o['count']
+            obj_type = o["type"]
+            total = o["count"]
 
     parsing_map = {
-        'computers': parse_computer,
-        'containers': parse_container,
-        'users': parse_user,
-        'groups': parse_group,
-        'domains': parse_domain,
-        'gpos': parse_gpo,
-        'ous': parse_ou
+        "computers": parse_computer,
+        "containers": parse_container,
+        "users": parse_user,
+        "groups": parse_group,
+        "domains": parse_domain,
+        "gpos": parse_gpo,
+        "ous": parse_ou,
     }
 
     parse_function = None
@@ -377,8 +488,8 @@ async def parse_file(filename: str, driver: neo4j.AsyncDriver):
 
     ten_percent = total // 10 if total > 10 else 1
     count = 0
-    f = codecs.open(filename, 'r', encoding='utf-8-sig')
-    objs = ijson.items(f, 'data.item')
+    f = codecs.open(filename, "r", encoding="utf-8-sig")
+    objs = ijson.items(f, "data.item")
     async with driver.session() as session:
         for entry in objs:
             try:
@@ -387,7 +498,9 @@ async def parse_file(filename: str, driver: neo4j.AsyncDriver):
             except neo4j.exceptions.ConstraintError as e:
                 print(e)
             if count % ten_percent == 0:
-                logging.info("Parsed %d out of %d records in %s.", count, total, filename)
+                logging.info(
+                    "Parsed %d out of %d records in %s.", count, total, filename
+                )
 
     f.close()
     logging.info("Completed file: %s", filename)


### PR DESCRIPTION
When using Bloodhound-Importer in conjuction with [BloodHound.py](https://github.com/fox-it/BloodHound.py)  in our environment, I encountered some cases where objects would be returned as 'flat' strings (only the object name) rather than dict objects, resulting in inaccurate data being imported.

This PR handles that edge case by implementing logic checks to verify if an object is the expected dict before processing it. To do this this it also modifies the `build_add_edge_query()` function to add an optional `type` parameter which has a safe default of `objectid`.

This PR also implements [Black formatting](https://github.com/psf/black) for Python files in a separate commit, which is a personal preference of mine.

I tried to make the code safe, such that no behavior should be affected in case the objects aren't affected by this edge case. It also should not impact performance in any significant way (tested on a large environment). It's very possible I made some mistakes or assumptions there though, in which case feel free to let me know :)